### PR TITLE
Version 0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Change Log
 
+## 0.0.5 2026/04/12
+- `Float#to_r` and `Float#to_r_exact` raise `FloatDomainError` when `self` is not finite.
+
 ## 0.0.4 2026/04/02
-- Add `Float#to_r_exact` that returns exact Rational value expressed by self.
+- Add `Float#to_r_exact` that returns exact Rational value expressed by `self`.
 
 ## 0.0.3 2024/12/03
 - Add `Kgl.#rpw`.

--- a/lib/kgl/kmath.rb
+++ b/lib/kgl/kmath.rb
@@ -15,6 +15,9 @@ end
 
 class Float
 	def to_r
+		unless self.finite?
+			raise FloatDomainError
+		end
 		str = self.to_s
 		(decimal, power) = str.split(/e/)
 		(integer, decimal) = decimal.split(/\./)
@@ -30,6 +33,9 @@ class Float
 		return Rational(numerator, denominator)
 	end
 	def to_r_exact
+		unless self.finite?
+			raise FloatDomainError
+		end
 		s, e = Math.frexp(self)
 		if e < 53
 			Rational(Math.ldexp(s, 53).to_i, 1<<(53-e))

--- a/lib/kgl/version.rb
+++ b/lib/kgl/version.rb
@@ -1,3 +1,3 @@
 module Kgl
-  VERSION = '0.0.4'
+  VERSION = '0.0.5'
 end


### PR DESCRIPTION
## 0.0.5 2026/04/12
- `Float#to_r` and `Float#to_r_exact` raise `FloatDomainError` when `self` is not finite.